### PR TITLE
Document v7.0.0 changes: short-circuit operators, prerequisites

### DIFF
--- a/content/en/docs/Overview/_index.md
+++ b/content/en/docs/Overview/_index.md
@@ -9,7 +9,7 @@ description: >
 ## What is it? {#what-is-it}
 
 Komapper is an ORM library for server-side Kotlin.
-Komapper supports Kotlin 1.5.31 or later.
+Komapper supports Kotlin 2.3.21 or later and requires JRE 17 or later.
 
 Komapper has several strengths as follows:
 

--- a/content/en/docs/Reference/Query/QueryDsl/template.md
+++ b/content/en/docs/Reference/Query/QueryDsl/template.md
@@ -484,6 +484,11 @@ These can be used as follows:
 /*% end */
 ```
 
+The `&&` and `||` operators are evaluated using short-circuit semantics, just like in Kotlin.
+That is, `&&` does not evaluate the right operand when the left operand is `false`,
+and `||` does not evaluate the right operand when the left operand is `true`.
+In the above example, `name.length > 0` is not evaluated when `name != null` is `false`.
+
 #### Property accesses {#sql-template-expression-property-access}
 
 To access properties, use `.` or `?.` as follows:

--- a/content/ja/docs/Overview/_index.md
+++ b/content/ja/docs/Overview/_index.md
@@ -9,7 +9,7 @@ description: >
 ## Komapperとは？ {#what-is-it}
 
 KomapperはサーバーサイドKotlinのためのORMライブラリーです。
-Kotlinの 1.5.31 以上をサポートします。
+Kotlinの 2.3.21 以上をサポートします。動作にはJREの 17 以上が必要です。
 
 Komapperにはいくつかの強みがあります。
 

--- a/content/ja/docs/Reference/Query/QueryDsl/template.md
+++ b/content/ja/docs/Reference/Query/QueryDsl/template.md
@@ -450,6 +450,11 @@ where
 /*% end */
 ```
 
+`&&` と `||` はKotlinと同様に短絡評価されます。
+つまり、`&&` は左オペランドが `false` の場合に右オペランドを評価せず、
+`||` は左オペランドが `true` の場合に右オペランドを評価しません。
+上記の例では、`name != null` が `false` の場合、`name.length > 0` は評価されません。
+
 #### プロパティアクセス {#sql-template-expression-property-access}
 
 `.`や`?.`を使ってプロパティにアクセスできます。`?.`はKotlinのsafe call operatorと同じ挙動をします。


### PR DESCRIPTION
## What changed

Documentation updates for the upcoming Komapper v7.0.0 release (English and Japanese kept in sync):

- **Template expression docs**: Added a paragraph to the Operators section explaining that `&&` and `||` are now evaluated with short-circuit semantics, just like in Kotlin (komapper/komapper#1881). This also makes the existing `name != null && name.length > 0` example genuinely safe, since the right operand is no longer evaluated when `name` is null.
- **Overview pages**: Replaced the stale "Komapper supports Kotlin 1.5.31 or later" statement with the current prerequisites from the upstream README: Kotlin 2.3.21 or later and JRE 17 or later. The JRE requirement reflects the JVM 11 -> 17 minimum raised in komapper/komapper#1889.

## Why

The v7.0.0 draft release contains one user-facing feature (short-circuit logical operators in template expressions) and a breaking change to the minimum JVM version, both of which should be reflected in the docs before release.

## Notes for reviewers

- The Quickstart and Examples pages already state JDK 17 and Gradle 7.6.4, so no changes were needed there.
- Version bumps (`gradle.properties`, `./gradlew updateVersion`, `config.toml`) are intentionally left out; they belong to the release step once v7.0.0 is published to Maven Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)