### PR TITLE
Automate the documentation release process

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: release
+description: Release a new version of the Komapper documentation site. Performs the main-branch release (version bumps, config.toml updates, new version branch), archives the previous version branch, and updates the Netlify configuration. Use when asked to release the docs for a new Komapper version, e.g. "/release 6.2.0".
+---
+
+# Komapper docs release
+
+Releases a new version of https://www.komapper.org/ following the process described in README.md.
+
+**Argument**: the full Komapper version to release, e.g. `6.2.0`. If not given, ask the user.
+
+**Derived values** (compute these up front and use them consistently):
+
+- `NEW_BRANCH`: `v` + major.minor of the Komapper version (`6.2.0` → `v6.2`).
+- `OLD_BRANCH`: the version at the top of the `[[params.versions]]` list in `config.toml` on main
+  (the uncommented entry whose url is `https://www.komapper.org/`), e.g. `v6.1`.
+- `OLD_SUBDOMAIN`: `OLD_BRANCH` with `.` replaced by `-`, plus the domain, e.g. `v6-1.komapper.org`.
+
+**Netlify site**: name `komapper`, site_id `ec21695f-242f-43af-8a30-2d13a84f0637`
+(the site_id also appears in the README status badge URL).
+
+## 1. Preconditions
+
+- Current branch is `main`, working tree is clean, and `git pull` reports up to date. Stop and ask if not.
+- Check Netlify API access: `netlify api getSite --data '{"site_id": "ec21695f-242f-43af-8a30-2d13a84f0637"}'`.
+  Requires the `netlify` CLI and either a logged-in session or `NETLIFY_AUTH_TOKEN`.
+  If this fails, do NOT abort: continue with the git/gradle steps and collect the Netlify
+  steps as manual instructions to present at the end.
+
+## 2. Determine dependency versions
+
+- Fetch `https://raw.githubusercontent.com/komapper/komapper/v<VERSION>/gradle/libs.versions.toml`
+  and read `kotlin = "..."` and `ksp = "..."` from the `[versions]` section.
+- If the tag does not exist yet, show the user what you found and ask for the Kotlin/KSP versions.
+- Update `gradle.properties`: `kotlinVersion`, `kspVersion`, `komapperVersion`.
+
+## 3. Release on main
+
+1. Run `./gradlew prepareRelease`. This updates version references in the content files and,
+   in `config.toml`: `version`, `github_branch`, and the `[[params.versions]]` list
+   (inserts `NEW_BRANCH` at the top, moves `OLD_BRANCH` to its subdomain URL).
+2. Review `git diff` and confirm it has the expected shape (compare with the previous
+   release commit, e.g. `git show <previous "Release vX.Y" commit> --stat`):
+   - `gradle.properties`: the three version numbers.
+   - `config.toml`: `version` and `github_branch` are `NEW_BRANCH`; list updated as described above.
+   - The six content files (en/ja Quickstart, annotation-processing, gradle-plugin) show the new versions.
+   Show the user a short diff summary. If anything looks wrong, stop before committing.
+3. Commit on main with message `Release <NEW_BRANCH>`, e.g. `Release v6.2`
+   (same style as previous release commits).
+4. Create the new branch: `git branch NEW_BRANCH`.
+5. Push both: `git push origin main NEW_BRANCH`.
+   Always push BEFORE switching the Netlify production branch, otherwise Netlify
+   tries to build a branch that does not exist.
+
+## 4. Switch the Netlify production branch
+
+1. `netlify api getSite --data '{"site_id": "..."}'` — note `build_settings.repo_branch`
+   (should be `OLD_BRANCH`) and `build_settings.allowed_branches`.
+2. Update: set `repo_branch` to `NEW_BRANCH` and make sure `OLD_BRANCH` is in `allowed_branches`
+   (so its subdomain keeps deploying as a branch deploy):
+
+   ```
+   netlify api updateSite --data '{"site_id": "...", "body": {"build_settings": {"repo_branch": "v6.2", "allowed_branches": [..existing.., "v6.1"]}}}'
+   ```
+
+3. Verify with `getSite` that the values actually changed. If the `build_settings` shape is
+   rejected or has no effect, retry with `{"body": {"repo": {"repo_branch": ..., "allowed_branches": [...]}}}`.
+4. If the API does not work, tell the user to do it in the Netlify UI:
+   Site configuration → Build & deploy → Continuous deployment → Branches and deploy contexts.
+
+## 5. Archive the old branch
+
+1. `git checkout OLD_BRANCH` (pull if it tracks a remote branch).
+2. Run `./gradlew archive`. This sets `archived_version = true`, `algolia_docsearch = false`,
+   `offlineSearch = true`, uncomments the `latest` entry in the versions list, and moves
+   `OLD_BRANCH` to its subdomain URL.
+3. Review `git diff` (compare with the previous `Archive vX.Y` commit), then commit with
+   message `Archive vX.Y` and push.
+4. `git checkout main`.
+
+## 6. Old-version subdomain
+
+- After the `OLD_BRANCH` branch deploy finishes, check whether `https://OLD_SUBDOMAIN/` resolves.
+- If Netlify "automatic deploy subdomains" is enabled for branch deploys, this works without
+  further action. Otherwise the user must add it manually in the Netlify UI:
+  Domain management → Branch subdomains → add `OLD_SUBDOMAIN` for branch `OLD_BRANCH`.
+
+## 7. Verify end to end
+
+1. Poll `netlify api listSiteDeploys --data '{"site_id": "..."}'` until the latest deploy for
+   `NEW_BRANCH` and the latest deploy for `OLD_BRANCH` both have `"state": "ready"`
+   (check every ~30s, give up after ~10 minutes and report).
+2. `curl -s https://www.komapper.org/` — the page must contain `NEW_BRANCH` (version selector).
+3. `curl -s https://OLD_SUBDOMAIN/` — must return the docs for `OLD_BRANCH`; ideally the
+   archived-version banner is present.
+4. Report a final checklist: what succeeded, what failed, and any remaining manual Netlify steps.
+
+## Safety rules
+
+- Never force-push.
+- Never commit if the diff deviates from the expected shape — show the user first.
+- If a step fails halfway, report exactly which steps are done and which remain, so the
+  release can be resumed manually.

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ tech-doc-hugo
 build
 
 /.hugo_build.lock
-/.claude/
+/.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ docker compose up
 
 # Version management
 ./gradlew updateVersion          # Update version numbers across documentation
-./gradlew archive               # Archive current version for release
+./gradlew prepareRelease         # updateVersion + update the version list in config.toml
+./gradlew archive               # Archive current version (config flags + version list)
 ./gradlew debug                 # Show current branch name
 
 # Direct Hugo (requires local Hugo installation)
@@ -34,9 +35,10 @@ hugo server --buildDrafts      # Include draft content
 
 ### Version Management System
 The project maintains multiple versions with sophisticated automation:
-- Version numbers defined in `gradle.properties` (currently Kotlin 2.1.21, KSP 2.0.1, Komapper 5.3.0)
+- Version numbers defined in `gradle.properties` (Kotlin, KSP, Komapper)
 - `updateVersion` task automatically updates version references across documentation
-- Each version gets its own branch and subdomain (e.g., v5-2.komapper.org)
+- `prepareRelease` task additionally maintains the `[[params.versions]]` list in `config.toml`
+- Each version gets its own branch and subdomain (e.g., v6-0.komapper.org)
 
 ### Content Structure
 ```
@@ -47,17 +49,19 @@ content/
 
 ## Release Process
 
+The release is automated by the `release` skill (`.claude/skills/release/SKILL.md`):
+run `/release <komapper-version>`. The underlying steps are:
+
 ### Main Branch Release
 1. Update version numbers in `gradle.properties`
-2. Run `./gradlew updateVersion`
-3. Update version URLs in `config.toml`
-4. Create new branch from main
-5. Configure Netlify for new branch
+2. Run `./gradlew prepareRelease` (also updates the version list in `config.toml`)
+3. Commit, create new branch from main, push both
+4. Switch the Netlify production branch to the new branch
 
 ### Archive Old Version
-1. In old branch, run `./gradlew archive`
-2. Update URLs in `config.toml`
-3. Create subdomain on Netlify
+1. In old branch, run `./gradlew archive` (also updates the version list in `config.toml`)
+2. Commit and push
+3. Create subdomain on Netlify (unless automatic deploy subdomains are enabled)
 
 ## Important Files
 

--- a/README.md
+++ b/README.md
@@ -12,21 +12,23 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Release steps
 
+The release process is automated with a Claude Code skill: run `/release <komapper-version>`
+(e.g. `/release 6.2.0`) in Claude Code. See [.claude/skills/release/SKILL.md](.claude/skills/release/SKILL.md).
+
+To release manually, follow the steps below.
+
 ### in the main branch
 
 1. Change version numbers in gradle.properties
-2. Execute `./gradlew updateVersion`
-3. Add new version and url in config.toml
-4. Change the url of old version in config.toml
-5. Commit changes
-6. Create a new branch from the main branch
-7. Change the new branch to a production branch on the Netlify page
-8. Push main and the new branches to remote
+2. Execute `./gradlew prepareRelease` (updates version references and the version list in config.toml)
+3. Commit changes
+4. Create a new branch from the main branch
+5. Push main and the new branches to remote
+6. Change the new branch to a production branch on the Netlify page
 
 ### in the old branch
 
-1. Execute `./gradlew archive`
-2. Change the url and add the latest url in config.toml
-3. Commit changes
-4. Push the branch to remote
-5. Create a new subdomain for the old branch on the Netlify page
+1. Execute `./gradlew archive` (also updates the version list in config.toml)
+2. Commit changes
+3. Push the branch to remote
+4. Create a new subdomain for the old branch on the Netlify page

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,51 @@ fun changeConfig(key :String, old: String, new: String) {
     }
 }
 
+val latestUrl = "https://www.komapper.org/"
+
+fun subdomainUrl(version: String) = "https://" + version.replace('.', '-') + ".komapper.org/"
+
+fun versionEntry(version: String, url: String) =
+    "[[params.versions]]\nversion = \"$version\"\nurl = \"$url\""
+
+// Insert the new version at the top of the [[params.versions]] list and
+// move the previous latest version to its own subdomain URL.
+fun addVersionToList() {
+    val configFile = file("config.toml")
+    val text = configFile.readText(charset(encoding))
+    val latestEntry = Regex("""(?<!#)\[\[params\.versions]]\nversion = "(v[^"]+)"\nurl = "https://www\.komapper\.org/"""")
+    val match = latestEntry.find(text)
+        ?: throw GradleException("Latest version entry not found in config.toml")
+    val previousVersion = match.groupValues[1]
+    if (previousVersion == branchName) {
+        println("config.toml already lists $branchName as the latest version")
+        return
+    }
+    val replacement = versionEntry(branchName, latestUrl) + "\n" +
+            versionEntry(previousVersion, subdomainUrl(previousVersion))
+    configFile.writeText(text.replaceRange(match.range, replacement), charset(encoding))
+    println("config.toml: added $branchName, moved $previousVersion to ${subdomainUrl(previousVersion)}")
+}
+
+// Uncomment the "latest" entry and point this branch's version to its subdomain URL.
+fun archiveVersionList() {
+    val configFile = file("config.toml")
+    val text = configFile.readText(charset(encoding))
+    val newText = text
+        .replace(
+            "#[[params.versions]]\n#version = \"latest\"\n#url = \"$latestUrl\"",
+            versionEntry("latest", latestUrl))
+        .replace(
+            versionEntry(branchName, latestUrl),
+            versionEntry(branchName, subdomainUrl(branchName)))
+    if (newText == text) {
+        println("config.toml: version list already archived")
+    } else {
+        configFile.writeText(newText, charset(encoding))
+        println("config.toml: enabled latest entry, moved $branchName to ${subdomainUrl(branchName)}")
+    }
+}
+
 tasks {
     register("updateVersion") {
         doLast {
@@ -50,11 +95,19 @@ tasks {
         }
     }
 
+    register("prepareRelease") {
+        dependsOn("updateVersion")
+        doLast {
+            addVersionToList()
+        }
+    }
+
     register("archive") {
         doLast {
             changeConfig("archived_version", "false", "true")
             changeConfig("algolia_docsearch", "true", "false")
             changeConfig("offlineSearch", "false", "true")
+            archiveVersionList()
         }
     }
 


### PR DESCRIPTION
## What changed

- **New `prepareRelease` Gradle task**: runs `updateVersion` and additionally maintains the `[[params.versions]]` list in `config.toml` — inserts the new version at the top pointing to https://www.komapper.org/ and moves the previous version to its `vX-Y.komapper.org` subdomain URL.
- **Extended `archive` task**: in addition to the existing config flag changes, it uncomments the `latest` entry and points the archived version at its subdomain URL.
- **New Claude Code skill** (`.claude/skills/release/SKILL.md`): a `/release <komapper-version>` runbook that automates the whole release — fetches Kotlin/KSP versions from the komapper repo's version catalog at the release tag, updates `gradle.properties`, runs `prepareRelease`, commits, creates and pushes the version branch, switches the Netlify production branch via the Netlify API, archives the old branch, and verifies the deployed sites end to end.
- **README.md / CLAUDE.md**: release steps updated; the manual `config.toml` edits are no longer needed.
- **.gitignore**: now ignores only `.claude/settings.local.json` instead of the whole `.claude/` directory, so the skill can be committed.

## Why

The release steps documented in the README required several manual, error-prone edits (the `config.toml` version list on both the main and the old branch) plus manual Netlify configuration. The `config.toml` edits are fully derivable from the version number, so they are now scripted; the orchestration and the Netlify steps are handled by the skill.

## Notes for the reviewer

- Both new tasks are idempotent: re-running them on an already released/archived state is a no-op, so an interrupted release can be resumed safely.
- Verified by simulating a v6.2.0 release on a working tree: `prepareRelease` reproduced the exact diff shape of the real `Release v6.1` commit (e038864), and `archive` reproduced the shape of `Archive v6.0` (376a259). All simulation changes were reverted.
- One-time setup still needed outside this repo: Netlify CLI auth (`netlify login` or `NETLIFY_AUTH_TOKEN`) for the API steps, and optionally enabling automatic deploy subdomains for branch deploys so the old-version subdomain step disappears entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)