### PR TITLE
Expand the Quickstart page into a full end-to-end tutorial

### DIFF
--- a/content/en/docs/Quickstart/_index.md
+++ b/content/en/docs/Quickstart/_index.md
@@ -10,6 +10,16 @@ description: >
 
 We show you how to create an application that uses JDBC to access H2 Database Engine.
 
+In this tutorial, you will:
+
+- Set up a Gradle project from scratch
+- Define an entity class and generate a metamodel at compile time
+- Write a program that creates a schema and performs basic CRUD operations —
+  insert, select, update, and delete — in a transaction
+
+The application accesses an in-memory H2 database,
+so you do not need to install or start a database server.
+
 ## Prerequisites {#prerequisites}
 
 - JDK 17 or later
@@ -24,6 +34,32 @@ We recommend that you install JDK using [sdkman](https://sdkman.io/).
 {{< /alert >}}
 
 ## Create Application {#create-application}
+
+### Project layout {#project-layout}
+
+The application consists of the following files:
+
+```
+komapper-quickstart/
+├── build.gradle.kts
+├── settings.gradle.kts
+└── src/
+    └── main/
+        └── kotlin/
+            └── org/
+                └── komapper/
+                    └── quickstart/
+                        ├── Application.kt
+                        └── Employee.kt
+```
+
+Create the directories, then define the project name in settings.gradle.kts:
+
+```kotlin
+rootProject.name = "komapper-quickstart"
+```
+
+The remaining files are explained in the following sections.
 
 ### Build Script {#build-script}
 
@@ -86,9 +122,19 @@ The following is an overview of each of the Komapper modules specified in the `d
 
 ### Source code {#source-code}
 
-First, create an entity class:
+First, create an entity class in Employee.kt:
 
 ```kotlin
+package org.komapper.quickstart
+
+import org.komapper.annotation.KomapperAutoIncrement
+import org.komapper.annotation.KomapperCreatedAt
+import org.komapper.annotation.KomapperEntity
+import org.komapper.annotation.KomapperId
+import org.komapper.annotation.KomapperUpdatedAt
+import org.komapper.annotation.KomapperVersion
+import java.time.LocalDateTime
+
 @KomapperEntity
 data class Employee(
   @KomapperId @KomapperAutoIncrement
@@ -103,12 +149,31 @@ data class Employee(
 )
 ```
 
+This is a plain Kotlin data class that is mapped to the `EMPLOYEE` table by annotations:
+
+- `@KomapperEntity`: Marks the class as an entity. The metamodel is generated from classes with this annotation.
+- `@KomapperId`: Marks the property as the primary key.
+- `@KomapperAutoIncrement`: Indicates that the primary key is generated using the database's auto-increment feature.
+- `@KomapperVersion`: Marks the property as the version number used for optimistic locking.
+- `@KomapperCreatedAt`: The timestamp is set automatically when the entity is inserted.
+- `@KomapperUpdatedAt`: The timestamp is set automatically when the entity is inserted or updated.
+
+For all available annotations, see [Entity Classes]({{< relref "../Reference/entity-class" >}}).
+
 Once you have finished creating the above class, [build]({{< relref "./#build" >}}) it.
 The metamodel code will be output and can be used in subsequent code.
 
-Next, create a main logic:
+Next, create a main logic in Application.kt:
 
 ```kotlin
+package org.komapper.quickstart
+
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.operator.count
+import org.komapper.core.dsl.query.first
+import org.komapper.jdbc.JdbcDatabase
+
 fun main() {
   // (1) create a database instance
   val database = JdbcDatabase("jdbc:h2:mem:quickstart;DB_CLOSE_DELAY=-1")
@@ -138,6 +203,28 @@ fun main() {
     for ((i, employee) in employees.withIndex()) {
       println("RESULT $i: $employee")
     }
+
+    // (8) select one employee by name
+    val employee = database.runQuery {
+      QueryDsl.from(e).where { e.name eq "AAA" }.first()
+    }
+
+    // (9) update the employee
+    val updated = database.runQuery {
+      QueryDsl.update(e).single(employee.copy(name = "CCC"))
+    }
+    println("UPDATED: $updated")
+
+    // (10) delete the employee
+    database.runQuery {
+      QueryDsl.delete(e).single(updated)
+    }
+
+    // (11) count the remaining employees
+    val count = database.runQuery {
+      QueryDsl.from(e).select(count())
+    }
+    println("COUNT: $count")
   }
 }
 ```
@@ -152,6 +239,25 @@ This feature is useful for creating simple samples, but is deprecated for use in
 5. Add multiple entities at once. 
 6. Retrieve all records as entities. 
 7. Output the retrieved entities.
+8. Retrieve the first row that matches the search criteria as an entity.
+Note that the `first` function is an extension function
+that must be imported from the `org.komapper.core.dsl.query` package.
+9. Update the entity. Because the entity is an immutable data class,
+create a modified copy with the `copy` function and pass it to the update query.
+The query returns the updated entity, whose version number is incremented.
+10. Delete the entity.
+11. Issue an aggregate query that counts the remaining employees.
+The `count` function is defined in the `org.komapper.core.dsl.operator` package.
+
+In the above code, query construction and execution are written together,
+but they can also be separated:
+
+```kotlin
+// build a query
+val query = QueryDsl.from(e).orderBy(e.id)
+// run the query
+val employees = database.runQuery(query)
+```
 
 ### Build {#build}
 
@@ -175,15 +281,34 @@ $ gradle run
 When you run the application, you will see the following output on the console:
 
 ```
-21:00:53.099 [main] DEBUG org.komapper.SQL - create table if not exists employee (id integer not null auto_increment, name varchar(500) not null, version integer not null, created_at timestamp not null, updated_at timestamp not null, constraint pk_employee primary key(id));
-21:00:53.117 [main] DEBUG org.komapper.SQL - insert into employee (name, version, created_at, updated_at) values (?, ?, ?, ?), (?, ?, ?, ?)
-21:00:53.140 [main] DEBUG org.komapper.SQL - select t0_.id, t0_.name, t0_.version, t0_.created_at, t0_.updated_at from employee as t0_ order by t0_.id asc
-RESULT 0: Employee(id=1, name=AAA, version=0, createdAt=2021-05-05T21:00:53.115127, updatedAt=2021-05-05T21:00:53.115127)
-RESULT 1: Employee(id=2, name=BBB, version=0, createdAt=2021-05-05T21:00:53.115250, updatedAt=2021-05-05T21:00:53.115250)
+07:02:18.613 [main] DEBUG org.komapper.Sql -- create table if not exists employee (id integer generated always as identity not null, name varchar(500) not null, version integer not null, created_at timestamp not null, updated_at timestamp not null, constraint pk_employee primary key(id))
+07:02:18.629 [main] DEBUG org.komapper.Sql -- insert into employee (name, version, created_at, updated_at) values (?, ?, ?, ?), (?, ?, ?, ?)
+07:02:18.648 [main] DEBUG org.komapper.Sql -- select t0_.id, t0_.name, t0_.version, t0_.created_at, t0_.updated_at from employee as t0_ order by t0_.id asc
+RESULT 0: Employee(id=1, name=AAA, version=0, createdAt=2026-06-13T07:02:18.624055, updatedAt=2026-06-13T07:02:18.624055)
+RESULT 1: Employee(id=2, name=BBB, version=0, createdAt=2026-06-13T07:02:18.624119, updatedAt=2026-06-13T07:02:18.624119)
+07:02:18.668 [main] DEBUG org.komapper.Sql -- select t0_.id, t0_.name, t0_.version, t0_.created_at, t0_.updated_at from employee as t0_ where t0_.name = ?
+07:02:18.673 [main] DEBUG org.komapper.Sql -- update employee set name = ?, version = ? + 1, updated_at = ? where id = ? and version = ?
+UPDATED: Employee(id=1, name=CCC, version=1, createdAt=2026-06-13T07:02:18.624055, updatedAt=2026-06-13T07:02:18.671793)
+07:02:18.675 [main] DEBUG org.komapper.Sql -- delete from employee as t0_ where t0_.id = ? and t0_.version = ?
+07:02:18.681 [main] DEBUG org.komapper.Sql -- select count(*) from employee as t0_
+COUNT: 1
 ```
 
-You can see that the Employee instance has been set with ID and timestamp.
-These were set automatically by Komapper.
+There are several points to note in this output:
+
+- The `Employee` instances have IDs and timestamps set.
+  These were set automatically by Komapper.
+- The executed SQL statements are logged at DEBUG level.
+  The komapper-starter-jdbc module includes an SLF4J adapter and Logback,
+  so no special logging configuration is required.
+  See [Logging]({{< relref "../Reference/logging" >}}) for details.
+- Look at the UPDATE statement.
+  Thanks to the `@KomapperVersion` annotation,
+  Komapper increments the `version` column and includes it in the WHERE clause (optimistic locking).
+  If the row had been changed by another transaction and the version no longer matched,
+  an `org.komapper.core.OptimisticLockException` would be thrown.
+  The version is checked in the DELETE statement in the same way.
+- The count is 1 because one of the two employees was deleted.
 
 ## Get complete code {#get-complete-code}
 
@@ -192,3 +317,9 @@ see https://github.com/komapper/komapper-quickstart
 
 In the above repository, Gradle Wrapper is available.
 So you can execute `./gradlew build` and `./gradlew run` instead of `gradle build` and `gradle run`.
+
+## Where should I go next? {#where-should-i-go-next}
+
+* [Examples]({{< relref "../Examples" >}}): More sample applications, including Spring Boot, Quarkus, and Ktor
+* [Queries]({{< relref "../Reference/Query" >}}): All supported query types in detail
+* [Entity Classes]({{< relref "../Reference/entity-class" >}}): All mapping annotations in detail

--- a/content/ja/docs/Quickstart/_index.md
+++ b/content/ja/docs/Quickstart/_index.md
@@ -10,6 +10,15 @@ description: >
 
 H2 Database EngineにJDBCで接続するアプリケーションを作成します。
 
+このチュートリアルでは以下のことを行います。
+
+- Gradleプロジェクトをゼロからセットアップする
+- エンティティクラスを定義し、コンパイル時にメタモデルを生成する
+- トランザクション内でスキーマの作成と基本的なCRUD操作（挿入・検索・更新・削除）を行うプログラムを書く
+
+アプリケーションはインメモリのH2データベースにアクセスするため、
+データベースサーバーのインストールや起動は不要です。
+
 ## 必要要件 {#prerequisites}
 
 - JDK 17、もしくはそれ以降のバージョン
@@ -24,6 +33,32 @@ JDKとGradleをインストールしてください。
 {{< /alert >}}
 
 ## アプリケーションの作成 {#create-application}
+
+### プロジェクトレイアウト {#project-layout}
+
+アプリケーションは以下のファイルで構成されます。
+
+```
+komapper-quickstart/
+├── build.gradle.kts
+├── settings.gradle.kts
+└── src/
+    └── main/
+        └── kotlin/
+            └── org/
+                └── komapper/
+                    └── quickstart/
+                        ├── Application.kt
+                        └── Employee.kt
+```
+
+ディレクトリを作成したら、settings.gradle.ktsにプロジェクト名を定義します。
+
+```kotlin
+rootProject.name = "komapper-quickstart"
+```
+
+残りのファイルについては以降のセクションで説明します。
 
 ### ビルドスクリプト {#build-script}
 
@@ -85,9 +120,19 @@ tasks {
 
 ### ソースコード {#source-code}
 
-最初に、データベースのテーブルに対応するエンティティクラスを作ります。
+最初に、データベースのテーブルに対応するエンティティクラスをEmployee.ktに作ります。
 
 ```kotlin
+package org.komapper.quickstart
+
+import org.komapper.annotation.KomapperAutoIncrement
+import org.komapper.annotation.KomapperCreatedAt
+import org.komapper.annotation.KomapperEntity
+import org.komapper.annotation.KomapperId
+import org.komapper.annotation.KomapperUpdatedAt
+import org.komapper.annotation.KomapperVersion
+import java.time.LocalDateTime
+
 @KomapperEntity
 data class Employee(
   @KomapperId @KomapperAutoIncrement
@@ -102,12 +147,32 @@ data class Employee(
 )
 ```
 
+このクラスは、アノテーションによって`EMPLOYEE`テーブルにマッピングされるプレーンなデータクラスです。
+
+- `@KomapperEntity`: エンティティであることを表します。このアノテーションが付与されたクラスからメタモデルが生成されます。
+- `@KomapperId`: プライマリキーであることを表します。
+- `@KomapperAutoIncrement`: プライマリキーがデータベースの自動インクリメント機能によって生成されることを表します。
+- `@KomapperVersion`: 楽観的排他制御に使われるバージョン番号であることを表します。
+- `@KomapperCreatedAt`: エンティティの挿入時にタイムスタンプが自動で設定されます。
+- `@KomapperUpdatedAt`: エンティティの挿入時と更新時にタイムスタンプが自動で設定されます。
+
+利用可能なすべてのアノテーションについては
+[エンティティクラス]({{< relref "../Reference/entity-class" >}}) を参照ください。
+
 上記のクラスの作成が終わったら一度 [ビルド]({{< relref "./#build" >}}) してください。
 メタモデルクラスのソースコードが出力され、後続のコードで利用できるようになります。
 
-次に、main関数を書きます。
+次に、main関数をApplication.ktに書きます。
 
 ```kotlin
+package org.komapper.quickstart
+
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.operator.count
+import org.komapper.core.dsl.query.first
+import org.komapper.jdbc.JdbcDatabase
+
 fun main() {
   // (1) create a database instance
   val database = JdbcDatabase("jdbc:h2:mem:quickstart;DB_CLOSE_DELAY=-1")
@@ -137,6 +202,28 @@ fun main() {
     for ((i, employee) in employees.withIndex()) {
       println("RESULT $i: $employee")
     }
+
+    // (8) select one employee by name
+    val employee = database.runQuery {
+      QueryDsl.from(e).where { e.name eq "AAA" }.first()
+    }
+
+    // (9) update the employee
+    val updated = database.runQuery {
+      QueryDsl.update(e).single(employee.copy(name = "CCC"))
+    }
+    println("UPDATED: $updated")
+
+    // (10) delete the employee
+    database.runQuery {
+      QueryDsl.delete(e).single(updated)
+    }
+
+    // (11) count the remaining employees
+    val count = database.runQuery {
+      QueryDsl.from(e).select(count())
+    }
+    println("COUNT: $count")
   }
 }
 ```
@@ -148,6 +235,13 @@ fun main() {
 5. 複数のエンティティを一度に追加します。
 6. 全件をエンティティとして取得します。
 7. 取得したエンティティをループで出力します。
+8. 検索条件にマッチした最初の行をエンティティとして取得します。
+`first`関数は拡張関数のため、`org.komapper.core.dsl.query`パッケージからのインポートが必要です。
+9. エンティティを更新します。エンティティは不変なデータクラスなので、`copy`関数で名前を変更したコピーを作り更新クエリに渡します。
+クエリはバージョン番号がインクリメントされた更新後のエンティティを返します。
+10. エンティティを削除します。
+11. 残っている従業員の数をカウントする集約クエリを発行します。
+`count`関数は`org.komapper.core.dsl.operator`パッケージで定義されています。
 
 上述のコードではクエリの構築と実行を同時に行っていますが、下記のように分けて行うこともできます。
 
@@ -180,15 +274,34 @@ $ gradle run
 アプリケーションを実行するとコンソール上に次のような出力が表示されます。
 
 ```
-21:00:53.099 [main] DEBUG org.komapper.SQL - create table if not exists employee (id integer not null auto_increment, name varchar(500) not null, version integer not null, created_at timestamp not null, updated_at timestamp not null, constraint pk_employee primary key(id));
-21:00:53.117 [main] DEBUG org.komapper.SQL - insert into employee (name, version, created_at, updated_at) values (?, ?, ?, ?), (?, ?, ?, ?)
-21:00:53.140 [main] DEBUG org.komapper.SQL - select t0_.id, t0_.name, t0_.version, t0_.created_at, t0_.updated_at from employee as t0_ order by t0_.id asc
-RESULT 0: Employee(id=1, name=AAA, version=0, createdAt=2021-05-05T21:00:53.115127, updatedAt=2021-05-05T21:00:53.115127)
-RESULT 1: Employee(id=2, name=BBB, version=0, createdAt=2021-05-05T21:00:53.115250, updatedAt=2021-05-05T21:00:53.115250)
+07:02:18.613 [main] DEBUG org.komapper.Sql -- create table if not exists employee (id integer generated always as identity not null, name varchar(500) not null, version integer not null, created_at timestamp not null, updated_at timestamp not null, constraint pk_employee primary key(id))
+07:02:18.629 [main] DEBUG org.komapper.Sql -- insert into employee (name, version, created_at, updated_at) values (?, ?, ?, ?), (?, ?, ?, ?)
+07:02:18.648 [main] DEBUG org.komapper.Sql -- select t0_.id, t0_.name, t0_.version, t0_.created_at, t0_.updated_at from employee as t0_ order by t0_.id asc
+RESULT 0: Employee(id=1, name=AAA, version=0, createdAt=2026-06-13T07:02:18.624055, updatedAt=2026-06-13T07:02:18.624055)
+RESULT 1: Employee(id=2, name=BBB, version=0, createdAt=2026-06-13T07:02:18.624119, updatedAt=2026-06-13T07:02:18.624119)
+07:02:18.668 [main] DEBUG org.komapper.Sql -- select t0_.id, t0_.name, t0_.version, t0_.created_at, t0_.updated_at from employee as t0_ where t0_.name = ?
+07:02:18.673 [main] DEBUG org.komapper.Sql -- update employee set name = ?, version = ? + 1, updated_at = ? where id = ? and version = ?
+UPDATED: Employee(id=1, name=CCC, version=1, createdAt=2026-06-13T07:02:18.624055, updatedAt=2026-06-13T07:02:18.671793)
+07:02:18.675 [main] DEBUG org.komapper.Sql -- delete from employee as t0_ where t0_.id = ? and t0_.version = ?
+07:02:18.681 [main] DEBUG org.komapper.Sql -- select count(*) from employee as t0_
+COUNT: 1
 ```
 
-EmployeeインスタンスにIDやタイムスタンプが設定されていることがわかります。
-これらはKomapperにより自動的に設定されました。
+この出力にはいくつかの注目すべきポイントがあります。
+
+- EmployeeインスタンスにIDやタイムスタンプが設定されています。
+  これらはKomapperにより自動的に設定されました。
+- 実行されたSQLがDEBUGレベルでログ出力されています。
+  komapper-starter-jdbcモジュールにはSLF4JのアダプタとLogbackが含まれているため、
+  特別なロギングの設定は不要です。
+  詳細は [ロギング]({{< relref "../Reference/logging" >}}) を参照ください。
+- UPDATE文に注目してください。
+  `@KomapperVersion`アノテーションを付与したことで、
+  Komapperは`version`カラムをインクリメントするとともにWHERE句の条件に含めています（楽観的排他制御）。
+  他のトランザクションによって行が変更されておりバージョンが一致しない場合は
+  `org.komapper.core.OptimisticLockException`がスローされます。
+  DELETE文でも同様にバージョンがチェックされます。
+- 2人の従業員のうち1人を削除したため、カウントは1になっています。
 
 ## 完全なコードの取得 {#get-complete-code}
 
@@ -207,3 +320,9 @@ $ ./gradlew build
 ```shell
 $ ./gradlew run
 ```
+
+## 次に見るべきドキュメント {#where-should-i-go-next}
+
+* [サンプルアプリケーション]({{< relref "../Examples" >}}): Spring Boot、Quarkus、Ktorなどのサンプル
+* [クエリ]({{< relref "../Reference/Query" >}}): サポートするすべてのクエリの詳細
+* [エンティティクラス]({{< relref "../Reference/entity-class" >}}): マッピング用アノテーションの詳細


### PR DESCRIPTION
## Summary

Expands the Quickstart page in both English and Japanese, addressing the Quickstart part of #34, which asked for a full end-to-end tutorial covering project setup, database configuration, and basic CRUD operations with sample configuration files and detailed explanations.

### Changes

- **Expanded overview**: states up front what the tutorial covers and that an in-memory H2 database is used, so no database server is needed
- **Project layout section**: the directory tree and `settings.gradle.kts`, so readers can set up the project from scratch
- **Complete source files**: `Employee.kt` and `Application.kt` are shown with package declarations and imports, making them copy-paste runnable
- **Annotation explanations**: each entity annotation (`@KomapperEntity`, `@KomapperId`, `@KomapperAutoIncrement`, `@KomapperVersion`, `@KomapperCreatedAt`, `@KomapperUpdatedAt`) is explained, with a link to the Entity Classes reference
- **Full CRUD**: the main program now continues past insert/select with steps 8–11 — select with a `where` condition, update via `copy()`, delete, and a `count()` aggregate — each with numbered explanations
- **Annotated console output**: explains the automatic ID/timestamps, zero-config SQL logging (the starter bundles SLF4J and Logback), optimistic locking visible in the UPDATE/DELETE statements, and `OptimisticLockException`
- **"Where should I go next?"**: links to Examples, Queries, and Entity Classes

### Verification

- I built and ran the tutorial's exact files as a real project against Komapper 6.1.0. This caught a genuine gotcha — `first()` requires `import org.komapper.core.dsl.query.first` — which the docs now show and call out
- The console output block is the actual captured output, which also refreshes stale details in the old sample: the logger name is now `org.komapper.Sql` (was `org.komapper.SQL`) and H2 DDL uses `generated always as identity` (was `auto_increment`)
- The `build.gradle.kts` code block is byte-identical to before, so the `updateVersion` Gradle task patterns still match (verified by running the task — no unexpected diff)
- Site builds cleanly with Hugo 0.104.3, the version Netlify uses

### Note for reviewers

The [komapper-quickstart](https://github.com/komapper/komapper-quickstart) repository's `Application.kt` currently ends at step 7. Consider adding steps 8–11 (plus the `count` and `first` imports) there so the "complete code" link matches the expanded tutorial.

Together with #39, this covers the Overview and Quickstart improvements requested in #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)