### PR TITLE
Raise the minimum Gradle version to 8.2

### DIFF
--- a/content/en/docs/Overview/_index.md
+++ b/content/en/docs/Overview/_index.md
@@ -14,7 +14,7 @@ To use Komapper, the following prerequisites must be met:
 
 - Kotlin 2.3.21 or later
 - JRE 17 or later
-- Gradle 7.6.4 or later
+- Gradle 8.2 or later
 
 Komapper has several strengths as follows:
 

--- a/content/en/docs/Quickstart/_index.md
+++ b/content/en/docs/Quickstart/_index.md
@@ -23,7 +23,7 @@ so you do not need to install or start a database server.
 ## Prerequisites {#prerequisites}
 
 - JDK 17 or later
-- Gradle 7.6.4 or later
+- Gradle 8.2 or later
 
 ## Install {#install}
 

--- a/content/ja/docs/Overview/_index.md
+++ b/content/ja/docs/Overview/_index.md
@@ -14,7 +14,7 @@ Komapperを利用するには以下の環境が必要です。
 
 - Kotlin 2.3.21 以上
 - JRE 17 以上
-- Gradle 7.6.4 以上
+- Gradle 8.2 以上
 
 Komapperにはいくつかの強みがあります。
 

--- a/content/ja/docs/Quickstart/_index.md
+++ b/content/ja/docs/Quickstart/_index.md
@@ -22,7 +22,7 @@ H2 Database EngineにJDBCで接続するアプリケーションを作成しま�
 ## 必要要件 {#prerequisites}
 
 - JDK 17、もしくはそれ以降のバージョン
-- Gradle 7.6.4、もしくはそれ以降のバージョン
+- Gradle 8.2、もしくはそれ以降のバージョン
 
 ## インストール {#install}
 


### PR DESCRIPTION
## Summary

Update the prerequisites on the Overview and Quickstart pages (both English and Japanese) to require Gradle 8.2 or later instead of 7.6.4 or later.

## Rationale

- Komapper 7.0.0 requires Kotlin 2.3.21 with standalone KSP (KSP 2.3.x). The Kotlin DSL in Gradle 7.6.x through 8.1.x cannot read the Kotlin 2.3 metadata contained in the standalone KSP plugin jar, and fails at configuration time with `Protocol message contained an invalid tag (zero)`. This is the same mechanism as [KT-73639](https://youtrack.jetbrains.com/issue/KT-73639).
- A bisection in [komapper/compatibility-test](https://github.com/komapper/compatibility-test/) confirmed that Gradle 8.1.1 fails while 8.2.1 succeeds, and the CI run for [compatibility-test#73](https://github.com/komapper/compatibility-test/pull/73) is green with Gradle 8.2.1 across Kotlin 2.3.0 / 2.3.21 / 2.4.0.
- This matches the compatibility matrix update in [komapper#1891](https://github.com/komapper/komapper/pull/1891).

🤖 Generated with [Claude Code](https://claude.com/claude-code)