### PR TITLE
Document context-parameter operators via FilterScope.criteriaContext

### DIFF
--- a/content/en/docs/Reference/Query/QueryDsl/expression.md
+++ b/content/en/docs/Reference/Query/QueryDsl/expression.md
@@ -1021,6 +1021,74 @@ order by
 */
 ```
 
+#### Using context parameters {#user-defined-expression-comparison-operator-context-parameter}
+
+If you are using Kotlin 2.4 or later, you can define operators using
+[context parameters](https://kotlinlang.org/docs/context-parameters.html)
+instead of the `extension` function.
+
+The `org.komapper.core.dsl.scope.FilterScope` interface exposes a `criteriaContext` property.
+By declaring a `context(scope: FilterScope<*>)` parameter on your operator function,
+you can add the SQL-generation logic to `scope.criteriaContext` directly.
+Because the implicit receiver inside a Where, Having, On, or When declaration is a `FilterScope`,
+the operator can be called without the `extension` wrapper.
+
+```kotlin
+context(scope: FilterScope<*>)
+infix fun <T : Any> ColumnExpression<T, String>.`~`(pattern: T?) {
+    if (pattern == null) return
+    val o1 = Operand.Column(this)
+    val o2 = Operand.Argument(this, pattern)
+    scope.criteriaContext.add {
+        visit(o1)
+        append(" ~ ")
+        visit(o2)
+    }
+}
+
+context(scope: FilterScope<*>)
+infix fun <T : Any> ColumnExpression<T, String>.`!~`(pattern: T?) {
+    if (pattern == null) return
+    val o1 = Operand.Column(this)
+    val o2 = Operand.Argument(this, pattern)
+    scope.criteriaContext.add {
+        visit(o1)
+        append(" !~ ")
+        visit(o2)
+    }
+}
+```
+
+The operators read exactly like the built-in ones at the call site, without the `extension` wrapper:
+
+```kotlin
+QueryDsl.from(e).where {
+    e.salary greaterEq BigDecimal(1000)
+    e.employeeName `~` "S"
+    e.employeeName `!~` "T"
+}.orderBy(e.employeeName)
+/*
+select 
+    t0_.EMPLOYEE_ID, 
+    t0_.EMPLOYEE_NO, 
+    t0_.EMPLOYEE_NAME, 
+    t0_.MANAGER_ID, 
+    t0_.HIREDATE, 
+    t0_.SALARY, 
+    t0_.DEPARTMENT_ID, 
+    t0_.ADDRESS_ID, 
+    t0_.VERSION 
+from 
+    EMPLOYEE as t0_ 
+where 
+    t0_.SALARY >= ?
+    t0_.EMPLOYEE_NAME ~ ?
+    t0_.EMPLOYEE_NAME !~ ?
+order by
+    t0_.EMPLOYEE_NAME
+*/
+```
+
 ### Custom column expressions {#user-defined-expression-column-expression}
 
 Define custom column expressions as Kotlin functions that return 

--- a/content/ja/docs/Reference/Query/QueryDsl/expression.md
+++ b/content/ja/docs/Reference/Query/QueryDsl/expression.md
@@ -1014,6 +1014,73 @@ order by
 */
 ```
 
+#### コンテキストパラメータを使う {#user-defined-expression-comparison-operator-context-parameter}
+
+Kotlin 2.4以降を使っている場合は、`extension`関数の代わりに
+[コンテキストパラメータ](https://kotlinlang.org/docs/context-parameters.html)を使って演算子を定義できます。
+
+`org.komapper.core.dsl.scope.FilterScope`インタフェースは`criteriaContext`プロパティを公開しています。
+演算子の関数に`context(scope: FilterScope<*>)`パラメータを宣言することで、
+SQLを生成する処理を`scope.criteriaContext`へ直接`add`できます。
+WhereやHaving、On、Whenの宣言の中の暗黙のレシーバーは`FilterScope`であるため、
+`extension`によるラッパーなしで演算子を呼び出せます。
+
+```kotlin
+context(scope: FilterScope<*>)
+infix fun <T : Any> ColumnExpression<T, String>.`~`(pattern: T?) {
+    if (pattern == null) return
+    val o1 = Operand.Column(this)
+    val o2 = Operand.Argument(this, pattern)
+    scope.criteriaContext.add {
+        visit(o1)
+        append(" ~ ")
+        visit(o2)
+    }
+}
+
+context(scope: FilterScope<*>)
+infix fun <T : Any> ColumnExpression<T, String>.`!~`(pattern: T?) {
+    if (pattern == null) return
+    val o1 = Operand.Column(this)
+    val o2 = Operand.Argument(this, pattern)
+    scope.criteriaContext.add {
+        visit(o1)
+        append(" !~ ")
+        visit(o2)
+    }
+}
+```
+
+演算子は、`extension`によるラッパーなしで、組み込みの演算子とまったく同じように呼び出せます。
+
+```kotlin
+QueryDsl.from(e).where {
+    e.salary greaterEq BigDecimal(1000)
+    e.employeeName `~` "S"
+    e.employeeName `!~` "T"
+}.orderBy(e.employeeName)
+/*
+select 
+    t0_.EMPLOYEE_ID, 
+    t0_.EMPLOYEE_NO, 
+    t0_.EMPLOYEE_NAME, 
+    t0_.MANAGER_ID, 
+    t0_.HIREDATE, 
+    t0_.SALARY, 
+    t0_.DEPARTMENT_ID, 
+    t0_.ADDRESS_ID, 
+    t0_.VERSION 
+from 
+    EMPLOYEE as t0_ 
+where 
+    t0_.SALARY >= ?
+    t0_.EMPLOYEE_NAME ~ ?
+    t0_.EMPLOYEE_NAME !~ ?
+order by
+    t0_.EMPLOYEE_NAME
+*/
+```
+
 ### 独自のカラム式 {#user-defined-expression-column-expression}
 
 独自のカラム式（例えば文字列関数など）は、`org.komapper.core.dsl.expression.ColumnExpression`を返す関数として定義します。


### PR DESCRIPTION
## Summary

Document the new way to define custom DSL comparison operators introduced in [komapper/komapper#1892](https://github.com/komapper/komapper/pull/1892), which exposes a public `criteriaContext` property on `FilterScope`.

A new **"Using context parameters"** subsection is added under **"Custom comparison operators"** in the QueryDsl expression reference, for both English and Japanese.

## What changed

- Added a subsection explaining that, on Kotlin 2.4+, users can define operators with a `context(scope: FilterScope<*>)` parameter and add SQL-generation logic to `scope.criteriaContext` directly.
- Because the implicit receiver inside a Where/Having/On/When declaration is a `FilterScope`, these operators can be called without the `extension { }` wrapper — presented as the ergonomic successor to the existing `extension(::MyExtension) { }` mechanism.
- Included an operator-definition example (`~` / `!~`) and a call-site usage example with the generated SQL.

## Notes for reviewers

- This is documentation-only; both `content/en` and `content/ja` are kept in sync.
- The existing `extension` function approach is left in place; the new subsection is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)